### PR TITLE
Change SKU to free tier

### DIFF
--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -58,7 +58,7 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2022-03-01' = {
   name: 'app-${resourceToken}'
   location: location
   sku: {
-    name: 'S1'
+    name: 'F1'
   }
   kind: 'linux'
   properties: {


### PR DESCRIPTION
The README says this template uses the Azure App Service free tier, but the current template uses the S1 (Standard) tier.